### PR TITLE
Fix order of classes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,4 +22,6 @@ class inspector {
 
   include inspector::install
   include inspector::service
+
+  Class['inspector::install'] -> Class['inspector::service']
 }


### PR DESCRIPTION
This fixes the order to make sure we first do the install of AWS inspector and only after the install activate the service. Earlier it was possible we tried to start the service before actually installing it, which caused Puppet errors.